### PR TITLE
feat: add Redis session handling and conversation logs

### DIFF
--- a/k-13-ai-main/package.json
+++ b/k-13-ai-main/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "k-13-ai-main",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "body-parser": "^1.20.2",
+    "connect-redis": "^7.1.0",
+    "cors": "^2.8.5",
+    "express": "^4.18.2",
+    "express-session": "^1.17.3",
+    "ioredis": "^5.3.2",
+    "jsonwebtoken": "^9.0.2",
+    "socket.io": "^4.7.5"
+  }
+}

--- a/k-13-ai-main/server/redisClient.js
+++ b/k-13-ai-main/server/redisClient.js
@@ -1,0 +1,8 @@
+const Redis = require('ioredis');
+
+const redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');
+
+redis.on('connect', () => console.log('Redis connected'));
+redis.on('error', (err) => console.error('Redis error', err));
+
+module.exports = redis;

--- a/k-13-ai-main/src/auth.js
+++ b/k-13-ai-main/src/auth.js
@@ -1,5 +1,6 @@
 import { generateSalt, hashPassword, verifyPassword } from './utils.js';
 import { logError, logDebug } from './utils.js';
+import redis from '../server/redisClient.js';
 
 export const handleAuth = {
   async login(request, env) {
@@ -27,25 +28,26 @@ export const handleAuth = {
         return new Response('으....이....', { status: 401 });
       }
       
-      // JWT 토큰 생성 (만료 시간 연장)
-      const token = btoa(JSON.stringify({ 
-        userId: user.id, 
-        exp: Date.now() + (24 * 60 * 60 * 1000), // 24시간
-        iat: Date.now() // 발급 시간 추가
+      // 세션 생성 및 저장
+      const token = btoa(JSON.stringify({
+        userId: user.id,
+        exp: Date.now() + (24 * 60 * 60 * 1000),
+        iat: Date.now()
       }));
-      
+      await redis.set(`session:${token}`, String(user.id), 'EX', 24 * 60 * 60);
+
       logDebug('토큰 생성 완료', 'Auth Login', { userId: user.id, tokenLength: token.length });
-      
+
       const url = new URL(request.url);
       const isSecure = url.protocol === 'https:';
-      
+
       const response = new Response(JSON.stringify({ success: true }), {
-        headers: { 
+        headers: {
           'Content-Type': 'application/json',
           'Cache-Control': 'no-cache, no-store, must-revalidate'
         }
       });
-      
+
       // 쿠키 설정 강화
       const cookieOptions = [
         `token=${token}`,
@@ -122,11 +124,17 @@ export const handleAuth = {
   async logout(request, env) {
     const url = new URL(request.url);
     const isSecure = url.protocol === 'https:';
-    
+
+    const cookieHeader = request.headers.get('Cookie') || '';
+    const tokenMatch = cookieHeader.match(/token=([^;]+)/);
+    if (tokenMatch) {
+      await redis.del(`session:${tokenMatch[1]}`);
+    }
+
     const response = new Response(JSON.stringify({ success: true }), {
       headers: { 'Content-Type': 'application/json' }
     });
-    
+
     const cookieOptions = [
       'token=',
       'HttpOnly',
@@ -134,17 +142,17 @@ export const handleAuth = {
       'Max-Age=0',
       'Path=/'
     ];
-    
-    if (!url.hostname.includes('localhost') && 
-        !url.hostname.includes('127.0.0.1') && 
+
+    if (!url.hostname.includes('localhost') &&
+        !url.hostname.includes('127.0.0.1') &&
         !url.hostname.includes('.local')) {
       cookieOptions.push(`Domain=${url.hostname}`);
     }
-    
+
     if (isSecure) {
       cookieOptions.push('Secure');
     }
-    
+
     response.headers.set('Set-Cookie', cookieOptions.join('; '));
     return response;
   }

--- a/k-13-ai-main/src/gemini.js
+++ b/k-13-ai-main/src/gemini.js
@@ -1,4 +1,5 @@
 import { logError } from './utils.js';
+import redis from '../server/redisClient.js';
 
 export async function handleChat(request, env) {
   try {
@@ -160,10 +161,14 @@ async function getUserFromToken(request, env) {
   
   const tokenMatch = cookies.match(/token=([^;]+)/);
   if (!tokenMatch) return null;
-  
+
   try {
     const tokenData = JSON.parse(atob(tokenMatch[1]));
     if (tokenData.exp < Date.now()) {
+        return null;
+    }
+    const sessionExists = await redis.get(`session:${tokenMatch[1]}`);
+    if (!sessionExists) {
         return null;
     }
     const user = await env.DB.prepare('SELECT * FROM users WHERE id = ?').bind(tokenData.userId).first();

--- a/k-13-ai-main/src/index.js
+++ b/k-13-ai-main/src/index.js
@@ -1,6 +1,7 @@
 import { handleAuth } from './auth.js';
 import { handleChat } from './gemini.js';
 import { logError, logDebug, getDebugLogs, clearDebugLogs, generateSalt, hashPassword, verifyPassword } from './utils.js';
+import redis from '../server/redisClient.js';
 
 export default {
   async fetch(request, env, ctx) {
@@ -325,6 +326,11 @@ async function getUserFromRequest(request, env) {
     
     // 토큰 만료 확인
     if (tokenData.exp < Date.now()) {
+      return null;
+    }
+
+    const sessionExists = await redis.get(`session:${tokenMatch[1]}`);
+    if (!sessionExists) {
       return null;
     }
     

--- a/k-13-ai-main/src/server.js
+++ b/k-13-ai-main/src/server.js
@@ -5,17 +5,16 @@ const socketIo = require('socket.io');
 const bodyParser = require('body-parser');
 const jwt = require('jsonwebtoken');
 const bcrypt = require('bcrypt');
-const Redis = require('ioredis');
 const cors = require('cors');
 require('dotenv').config();
 const fs = require('fs');
 const toml = require('toml');
 const { v4: uuidv4 } = require('uuid');
+const redis = require('../server/redisClient');
 
 const app = express();
 const server = http.createServer(app);
 const io = socketIo(server, { cors: { origin: '*' } });
-const redis = new Redis(process.env.REDIS_URL || 'redis://localhost:6379');
 
 const JWT_SECRET = process.env.JWT_SECRET || 'secret';
 
@@ -136,6 +135,19 @@ app.get('/api/chatlog', async (req, res) => {
   }
 });
 
+// 전체 대화 기록 조회
+app.get('/api/conversations', async (req, res) => {
+  const { token } = req.query;
+  try {
+    const { id } = jwt.verify(token, JWT_SECRET);
+    const convKey = `conversations:${id}`;
+    const messages = await redis.lrange(convKey, 0, -1);
+    res.json({ messages: messages.map(JSON.parse) });
+  } catch {
+    res.status(401).json({ error: '인증 실패' });
+  }
+});
+
 // 비밀번호 변경
 app.post('/api/change-password', async (req, res) => {
   const { token, currentPassword, newPassword } = req.body;
@@ -196,6 +208,8 @@ io.on('connection', (socket) => {
     const aiLog = { role: 'ai', message: aiReply, time: Date.now(), model };
     const sessionKey = `chatlog:${socket.id_}:${socket.sessionId}`;
     await redis.rpush(sessionKey, JSON.stringify(log), JSON.stringify(aiLog));
+    const convKey = `conversations:${socket.id_}`;
+    await redis.rpush(convKey, JSON.stringify(log), JSON.stringify(aiLog));
     // 세션 미리보기(최초 메시지) 갱신
     const sessions = await redis.lrange(`chatlog:${socket.id_}:sessions`, 0, -1);
     if (sessions.length > 0) {


### PR DESCRIPTION
## Summary
- add Redis client module for centralized connection
- store and clear auth sessions in Redis
- log socket.io chats to Redis and expose them via `/api/conversations`

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm install express socket.io ioredis express-session connect-redis body-parser jsonwebtoken bcrypt cors` *(fails: 403 Forbidden - GET https://registry.npmjs.org/bcrypt)*

------
https://chatgpt.com/codex/tasks/task_e_689bfa5b133083228ab4f221a3cf3850